### PR TITLE
Fix download_model()

### DIFF
--- a/download.py
+++ b/download.py
@@ -8,6 +8,5 @@ import torch
 
 def download_model():
     model = whisper.load_model("base")
-    dobum
 if __name__ == "__main__":
     download_model()


### PR DESCRIPTION
This line is breaking the template. I was able to run the model after removing it.